### PR TITLE
feat: add track editor and stabilize vocal capture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+node_modules
+.DS_Store
+npm-debug.log*
+vite.svg
+dist

--- a/README.md
+++ b/README.md
@@ -1,1 +1,48 @@
-# Viveye.
+# vocalstudio
+
+vocalstudio is a focused audio production environment for artists who already have their beat. Drag and drop your instrumental, capture pristine vocals, shape the performance with studio-grade effects, and master a final bounce ready for sharing.
+
+## Features
+
+- **Beat-first workflow** – import a beat via drag-and-drop or file picker and immediately monitor tempo and length.
+- **Tempo intelligence** – automatic BPM and downbeat detection locks the session grid without touching the instrumental.
+- **Guided vocal capture** – one-click record with live monitoring, waveform-safe buffering, and automatic take management.
+- **Premium processing** powered by the Web Audio API:
+  - Three-band equaliser tuned for vocal sculpting.
+  - Transparent dynamics control with configurable compressor parameters.
+  - Tempo-synced delay with feedback and mix control.
+  - Lush algorithmic reverb with adjustable tail length and decay.
+- **Instrumental preservation** – the imported beat bypasses vocal effects so its dynamics and tempo remain pristine.
+- **Flow alignment** – quantise recorded takes to the detected beat grid for effortless on-tempo playback and export.
+- **Master-ready output** – real-time mix adjustments feed a mastering chain that you can export as a high-quality WebM file with a single click.
+- **Responsive, modern UI** – clean panels keep the focus on the sound while staying usable on desktops and tablets.
+- **Track overview** – dedicated beat and vocal lanes surface statuses at a glance so you can stay organised before mixing.
+
+## Getting started
+
+```bash
+npm install
+npm run dev
+```
+
+The development server is exposed on <http://localhost:5173> by default.
+
+To produce a static build run:
+
+```bash
+npm run build
+```
+
+The built assets are emitted to the `dist/` directory.
+
+## Recording permissions
+
+The app uses your browser microphone. The first time you hit **Record** your browser will request permission. Granting access is required for vocal capture and for mixdown exports.
+
+## Exporting a mix
+
+When you choose **Export Master** the engine prints the current beat and vocal take through the processing chain to a WebM file. Keep the tab in focus during rendering to ensure uninterrupted capture.
+
+## License
+
+MIT

--- a/index.html
+++ b/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>vocalstudio</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1773 @@
+{
+  "name": "vocalstudio",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "vocalstudio",
+      "version": "1.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "react": "^19.1.1",
+        "react-dom": "^19.1.1"
+      },
+      "devDependencies": {
+        "@types/react": "^19.1.4",
+        "@types/react-dom": "^19.1.5",
+        "@vitejs/plugin-react": "^4.5.3",
+        "typescript": "^5.9.2",
+        "vite": "^6.0.5"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.28.4.tgz",
+      "integrity": "sha512-YsmSKC29MJwf0gF8Rjjrg5LQCmyh+j/nD8/eP7f+BeoQTKYqs9RoWbjGOdy0+1Ekr68RJZMUOPVQaQisnIo4Rw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.4.tgz",
+      "integrity": "sha512-2BCOP7TN8M+gVDj7/ht3hsaO/B/n5oDbiAyyvnRlNOs+u1o+JWNYTQrmpuNp1/Wq2gcFrI01JAW+paEKDMx/CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-compilation-targets": "^7.27.2",
+        "@babel/helper-module-transforms": "^7.28.3",
+        "@babel/helpers": "^7.28.4",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/traverse": "^7.28.4",
+        "@babel/types": "^7.28.4",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.28.3.tgz",
+      "integrity": "sha512-3lSpxGgvnmZznmBkCRnVREPUFJv2wrv9iAoFDvADJc0ypmdOxdUtcLeBgBJ6zE0PMeTKnxeQzyk0xTBq4Ep7zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.28.3",
+        "@babel/types": "^7.28.2",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.27.2.tgz",
+      "integrity": "sha512-2+1thGUUWWjLTYTHZWK1n8Yga0ijBz1XAhUXcKy81rd5g6yh7hGqMp45v7cadSbEHc9G3OTv45SyneRN3ps4DQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.27.2",
+        "@babel/helper-validator-option": "^7.27.1",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
+      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.27.1.tgz",
+      "integrity": "sha512-0gSFWUPNXNopqtIPQvlD5WgXYI5GY2kP2cCvoT8kczjbfcfuIljTbcWrulD1CIPIX2gt1wghbDy08yE1p+/r3w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.27.1",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.28.3",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.3.tgz",
+      "integrity": "sha512-gytXUbs8k2sXS9PnQptz5o0QnpLL51SwASIORY6XaBKF88nsOT0Zw9szLqlSGQDP/4TljBAD5y98p2U1fqkdsw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "@babel/traverse": "^7.28.3"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.27.1.tgz",
+      "integrity": "sha512-1gn1Up5YXka3YYAHGKpbideQ5Yjf1tDa9qYcgysz+cNCXukyLl6DjPXhD3VRwSb8c0J9tA4b2+rHEZtc6R0tlw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
+      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.28.4.tgz",
+      "integrity": "sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.28.4.tgz",
+      "integrity": "sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.4"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.27.1.tgz",
+      "integrity": "sha512-6UzkCs+ejGdZ5mFFC/OCUrv028ab2fp1znZmCZjAOBKiBK2jXD1O+BPSfX8X2qjJ75fZBMSnQn3Rq2mrBJK2mw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.27.1.tgz",
+      "integrity": "sha512-zbwoTsBruTeKB9hSq73ha66iFeJHuaFkUbwvqElnygoNbj/jHRsSeokowZFN3CZ64IvEqcmmkVe89OPXc7ldAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.4.tgz",
+      "integrity": "sha512-YEzuboP2qvQavAcjgQNVgsvHIDv6ZpwXvcvjmyySP2DIMuByS/6ioU5G9pYrWHM6T2YDfc7xga9iNzYOs12CFQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.28.3",
+        "@babel/helper-globals": "^7.28.0",
+        "@babel/parser": "^7.28.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.28.4",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.28.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.28.4.tgz",
+      "integrity": "sha512-bkFqkLhh3pMBUQQkpVgWDWq/lqzc2678eUyDlTBhRqhCHFguYYGM0Efga7tYk4TogG/3x0EEl66/OQ+WGbWB/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.10.tgz",
+      "integrity": "sha512-0NFWnA+7l41irNuaSVlLfgNT12caWJVLzp5eAVhZ0z1qpxbockccEt3s+149rE64VUI3Ml2zt8Nv5JVc4QXTsw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.10.tgz",
+      "integrity": "sha512-dQAxF1dW1C3zpeCDc5KqIYuZ1tgAdRXNoZP7vkBIRtKZPYe2xVr/d3SkirklCHudW1B45tGiUlz2pUWDfbDD4w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.10.tgz",
+      "integrity": "sha512-LSQa7eDahypv/VO6WKohZGPSJDq5OVOo3UoFR1E4t4Gj1W7zEQMUhI+lo81H+DtB+kP+tDgBp+M4oNCwp6kffg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.10.tgz",
+      "integrity": "sha512-MiC9CWdPrfhibcXwr39p9ha1x0lZJ9KaVfvzA0Wxwz9ETX4v5CHfF09bx935nHlhi+MxhA63dKRRQLiVgSUtEg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.10.tgz",
+      "integrity": "sha512-JC74bdXcQEpW9KkV326WpZZjLguSZ3DfS8wrrvPMHgQOIEIG/sPXEN/V8IssoJhbefLRcRqw6RQH2NnpdprtMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.10.tgz",
+      "integrity": "sha512-tguWg1olF6DGqzws97pKZ8G2L7Ig1vjDmGTwcTuYHbuU6TTjJe5FXbgs5C1BBzHbJ2bo1m3WkQDbWO2PvamRcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-3ZioSQSg1HT2N05YxeJWYR+Libe3bREVSdWhEEgExWaDtyFbbXWb49QgPvFH8u03vUPX10JhJPcz7s9t9+boWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.10.tgz",
+      "integrity": "sha512-LLgJfHJk014Aa4anGDbh8bmI5Lk+QidDmGzuC2D+vP7mv/GeSN+H39zOf7pN5N8p059FcOfs2bVlrRr4SK9WxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.10.tgz",
+      "integrity": "sha512-oR31GtBTFYCqEBALI9r6WxoU/ZofZl962pouZRTEYECvNF/dtXKku8YXcJkhgK/beU+zedXfIzHijSRapJY3vg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.10.tgz",
+      "integrity": "sha512-5luJWN6YKBsawd5f9i4+c+geYiVEw20FVW5x0v1kEMWNq8UctFjDiMATBxLvmmHA4bf7F6hTRaJgtghFr9iziQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.10.tgz",
+      "integrity": "sha512-NrSCx2Kim3EnnWgS4Txn0QGt0Xipoumb6z6sUtl5bOEZIVKhzfyp/Lyw4C1DIYvzeW/5mWYPBFJU3a/8Yr75DQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.10.tgz",
+      "integrity": "sha512-xoSphrd4AZda8+rUDDfD9J6FUMjrkTz8itpTITM4/xgerAZZcFW7Dv+sun7333IfKxGG8gAq+3NbfEMJfiY+Eg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.10.tgz",
+      "integrity": "sha512-ab6eiuCwoMmYDyTnyptoKkVS3k8fy/1Uvq7Dj5czXI6DF2GqD2ToInBI0SHOp5/X1BdZ26RKc5+qjQNGRBelRA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.10.tgz",
+      "integrity": "sha512-NLinzzOgZQsGpsTkEbdJTCanwA5/wozN9dSgEl12haXJBzMTpssebuXR42bthOF3z7zXFWH1AmvWunUCkBE4EA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.10.tgz",
+      "integrity": "sha512-FE557XdZDrtX8NMIeA8LBJX3dC2M8VGXwfrQWU7LB5SLOajfJIxmSdyL/gU1m64Zs9CBKvm4UAuBp5aJ8OgnrA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.10.tgz",
+      "integrity": "sha512-3BBSbgzuB9ajLoVZk0mGu+EHlBwkusRmeNYdqmznmMc9zGASFjSsxgkNsqmXugpPk00gJ0JNKh/97nxmjctdew==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.10.tgz",
+      "integrity": "sha512-QSX81KhFoZGwenVyPoberggdW1nrQZSvfVDAIUXr3WqLRZGZqWk/P4T8p2SP+de2Sr5HPcvjhcJzEiulKgnxtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-AKQM3gfYfSW8XRk8DdMCzaLUFB15dTrZfnX8WXQoOUpUBQ+NaAFCP1kPS/ykbbGYz7rxn0WS48/81l9hFl3u4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-7RTytDPGU6fek/hWuN9qQpeGPBZFfB4zZgcz2VK2Z5VpdUxEI8JKYsg3JfO0n/Z1E/6l05n0unDCNc4HnhQGig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.10.tgz",
+      "integrity": "sha512-5Se0VM9Wtq797YFn+dLimf2Zx6McttsH2olUBsDml+lm0GOCRVebRWUvDtkY4BWYv/3NgzS8b/UM3jQNh5hYyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.10.tgz",
+      "integrity": "sha512-XkA4frq1TLj4bEMB+2HnI0+4RnjbuGZfet2gs/LNs5Hc7D89ZQBHQ0gL2ND6Lzu1+QVkjp3x1gIcPKzRNP8bXw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.10.tgz",
+      "integrity": "sha512-AVTSBhTX8Y/Fz6OmIVBip9tJzZEUcY8WLh7I59+upa5/GPhh2/aM6bvOMQySspnCCHvFi79kMtdJS1w0DXAeag==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.10.tgz",
+      "integrity": "sha512-fswk3XT0Uf2pGJmOpDB7yknqhVkJQkAQOcW/ccVOtfx05LkbWOaRAtn5SaqXypeKQra1QaEa841PgrSL9ubSPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.10.tgz",
+      "integrity": "sha512-ah+9b59KDTSfpaCg6VdJoOQvKjI33nTaQr4UluQwW7aEwZQsbMCfTmfEO4VyewOxx4RaDT/xCy9ra2GPWmO7Kw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.10.tgz",
+      "integrity": "sha512-QHPDbKkrGO8/cz9LKVnJU22HOi4pxZnZhhA2HYHez5Pz4JeffhDjf85E57Oyco163GnzNCVkZK0b/n4Y0UHcSw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.10.tgz",
+      "integrity": "sha512-9KpxSVFCu0iK1owoez6aC/s/EdUQLDN3adTxGCqxMVhrPDj6bt5dbrHDXUuq+Bs2vATFBBrQS5vdQ/Ed2P+nbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.52.2.tgz",
+      "integrity": "sha512-o3pcKzJgSGt4d74lSZ+OCnHwkKBeAbFDmbEm5gg70eA8VkyCuC/zV9TwBnmw6VjDlRdF4Pshfb+WE9E6XY1PoQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.52.2.tgz",
+      "integrity": "sha512-cqFSWO5tX2vhC9hJTK8WAiPIm4Q8q/cU8j2HQA0L3E1uXvBYbOZMhE2oFL8n2pKB5sOCHY6bBuHaRwG7TkfJyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.52.2.tgz",
+      "integrity": "sha512-vngduywkkv8Fkh3wIZf5nFPXzWsNsVu1kvtLETWxTFf/5opZmflgVSeLgdHR56RQh71xhPhWoOkEBvbehwTlVA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.52.2.tgz",
+      "integrity": "sha512-h11KikYrUCYTrDj6h939hhMNlqU2fo/X4NB0OZcys3fya49o1hmFaczAiJWVAFgrM1NCP6RrO7lQKeVYSKBPSQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.52.2.tgz",
+      "integrity": "sha512-/eg4CI61ZUkLXxMHyVlmlGrSQZ34xqWlZNW43IAU4RmdzWEx0mQJ2mN/Cx4IHLVZFL6UBGAh+/GXhgvGb+nVxw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.52.2.tgz",
+      "integrity": "sha512-QOWgFH5X9+p+S1NAfOqc0z8qEpJIoUHf7OWjNUGOeW18Mx22lAUOiA9b6r2/vpzLdfxi/f+VWsYjUOMCcYh0Ng==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.52.2.tgz",
+      "integrity": "sha512-kDWSPafToDd8LcBYd1t5jw7bD5Ojcu12S3uT372e5HKPzQt532vW+rGFFOaiR0opxePyUkHrwz8iWYEyH1IIQA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.52.2.tgz",
+      "integrity": "sha512-gKm7Mk9wCv6/rkzwCiUC4KnevYhlf8ztBrDRT9g/u//1fZLapSRc+eDZj2Eu2wpJ+0RzUKgtNijnVIB4ZxyL+w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.52.2.tgz",
+      "integrity": "sha512-66lA8vnj5mB/rtDNwPgrrKUOtCLVQypkyDa2gMfOefXK6rcZAxKLO9Fy3GkW8VkPnENv9hBkNOFfGLf6rNKGUg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.52.2.tgz",
+      "integrity": "sha512-s+OPucLNdJHvuZHuIz2WwncJ+SfWHFEmlC5nKMUgAelUeBUnlB4wt7rXWiyG4Zn07uY2Dd+SGyVa9oyLkVGOjA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.52.2.tgz",
+      "integrity": "sha512-8wTRM3+gVMDLLDdaT6tKmOE3lJyRy9NpJUS/ZRWmLCmOPIJhVyXwjBo+XbrrwtV33Em1/eCTd5TuGJm4+DmYjw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.52.2.tgz",
+      "integrity": "sha512-6yqEfgJ1anIeuP2P/zhtfBlDpXUb80t8DpbYwXQ3bQd95JMvUaqiX+fKqYqUwZXqdJDd8xdilNtsHM2N0cFm6A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.52.2.tgz",
+      "integrity": "sha512-sshYUiYVSEI2B6dp4jMncwxbrUqRdNApF2c3bhtLAU0qA8Lrri0p0NauOsTWh3yCCCDyBOjESHMExonp7Nzc0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.52.2.tgz",
+      "integrity": "sha512-duBLgd+3pqC4MMwBrKkFxaZerUxZcYApQVC5SdbF5/e/589GwVvlRUnyqMFbM8iUSb1BaoX/3fRL7hB9m2Pj8Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.52.2.tgz",
+      "integrity": "sha512-tzhYJJidDUVGMgVyE+PmxENPHlvvqm1KILjjZhB8/xHYqAGeizh3GBGf9u6WdJpZrz1aCpIIHG0LgJgH9rVjHQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-opH8GSUuVcCSSyHHcl5hELrmnk4waZoVpgn/4FDao9iyE4WpQhyWJ5ryl5M3ocp4qkRuHfyXnGqg8M9oKCEKRA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.52.2.tgz",
+      "integrity": "sha512-LSeBHnGli1pPKVJ79ZVJgeZWWZXkEe/5o8kcn23M8eMKCUANejchJbF/JqzM4RRjOJfNRhKJk8FuqL1GKjF5oQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.52.2.tgz",
+      "integrity": "sha512-uPj7MQ6/s+/GOpolavm6BPo+6CbhbKYyZHUDvZ/SmJM7pfDBgdGisFX3bY/CBDMg2ZO4utfhlApkSfZ92yXw7Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.52.2.tgz",
+      "integrity": "sha512-Z9MUCrSgIaUeeHAiNkm3cQyst2UhzjPraR3gYYfOjAuZI7tcFRTOD+4cHLPoS/3qinchth+V56vtqz1Tv+6KPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.52.2.tgz",
+      "integrity": "sha512-+GnYBmpjldD3XQd+HMejo+0gJGwYIOfFeoBQv32xF/RUIvccUz20/V6Otdv+57NE70D5pa8W/jVGDoGq0oON4A==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.52.2.tgz",
+      "integrity": "sha512-ApXFKluSB6kDQkAqZOKXBjiaqdF1BlKi+/eqnYe9Ee7U2K3pUDKsIyr8EYm/QDHTJIM+4X+lI0gJc3TTRhd+dA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.52.2.tgz",
+      "integrity": "sha512-ARz+Bs8kY6FtitYM96PqPEVvPXqEZmPZsSkXvyX19YzDqkCaIlhCieLLMI5hxO9SRZ2XtCtm8wxhy0iJ2jxNfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "19.1.13",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.1.13.tgz",
+      "integrity": "sha512-hHkbU/eoO3EG5/MZkuFSKmYqPbSVk5byPFa3e7y/8TybHiLMACgI8seVYlicwk7H5K/rI2px9xrQp/C+AUDTiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "19.1.9",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.1.9.tgz",
+      "integrity": "sha512-qXRuZaOsAdXKFyOhRBg6Lqqc0yay13vN7KrIg4L7N4aaHN68ma9OK3NE1BoDFgFOTfM7zg+3/8+2n8rLUH3OKQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^19.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.8.6.tgz",
+      "integrity": "sha512-wrH5NNqren/QMtKUEEJf7z86YjfqW/2uw3IL3/xpqZUC95SSVIFXYQeeGjL6FT/X68IROu6RMehZQS5foy2BXw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.26.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.26.2.tgz",
+      "integrity": "sha512-ECFzp6uFOSB+dcZ5BK/IBaGWssbSYBHvuMeMt3MMFyhI0Z8SqGgEkBLARgpRH3hutIgPVsALcMwbDrJqPxQ65A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.8.3",
+        "caniuse-lite": "^1.0.30001741",
+        "electron-to-chromium": "^1.5.218",
+        "node-releases": "^2.0.21",
+        "update-browserslist-db": "^1.1.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001743",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001743.tgz",
+      "integrity": "sha512-e6Ojr7RV14Un7dz6ASD0aZDmQPT/A+eZU+nuTNfjqmRrmkmQlnTNWH0SKmqagx9PeW87UVqapSurtAXifmtdmw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
+      "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.223",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.223.tgz",
+      "integrity": "sha512-qKm55ic6nbEmagFlTFczML33rF90aU+WtrJ9MdTCThrcvDNdUHN4p6QfVN78U06ZmguqXIyMPyYhw2TrbDUwPQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.10",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.10.tgz",
+      "integrity": "sha512-9RiGKvCwaqxO2owP61uQ4BgNborAQskMR6QusfWzQqv7AZOg5oGehdY2pRJMTKuwxd1IDBP4rSbI5lHzU7SMsQ==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.10",
+        "@esbuild/android-arm": "0.25.10",
+        "@esbuild/android-arm64": "0.25.10",
+        "@esbuild/android-x64": "0.25.10",
+        "@esbuild/darwin-arm64": "0.25.10",
+        "@esbuild/darwin-x64": "0.25.10",
+        "@esbuild/freebsd-arm64": "0.25.10",
+        "@esbuild/freebsd-x64": "0.25.10",
+        "@esbuild/linux-arm": "0.25.10",
+        "@esbuild/linux-arm64": "0.25.10",
+        "@esbuild/linux-ia32": "0.25.10",
+        "@esbuild/linux-loong64": "0.25.10",
+        "@esbuild/linux-mips64el": "0.25.10",
+        "@esbuild/linux-ppc64": "0.25.10",
+        "@esbuild/linux-riscv64": "0.25.10",
+        "@esbuild/linux-s390x": "0.25.10",
+        "@esbuild/linux-x64": "0.25.10",
+        "@esbuild/netbsd-arm64": "0.25.10",
+        "@esbuild/netbsd-x64": "0.25.10",
+        "@esbuild/openbsd-arm64": "0.25.10",
+        "@esbuild/openbsd-x64": "0.25.10",
+        "@esbuild/openharmony-arm64": "0.25.10",
+        "@esbuild/sunos-x64": "0.25.10",
+        "@esbuild/win32-arm64": "0.25.10",
+        "@esbuild/win32-ia32": "0.25.10",
+        "@esbuild/win32-x64": "0.25.10"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.21",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.21.tgz",
+      "integrity": "sha512-5b0pgg78U3hwXkCM8Z9b2FJdPZlr9Psr9V2gQPESdGHqbntyFJKFW4r5TeWGFzafGY3hzs1JC62VEQMbl1JFkw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
+      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.6",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
+      "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/react": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-19.1.1.tgz",
+      "integrity": "sha512-w8nqGImo45dmMIfljjMwOGtbmC/mk4CMYhWIicdSflH91J9TyCyczcPFXJzrZ/ZXcgGRFeP6BU0BEJTw6tZdfQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "19.1.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
+      "integrity": "sha512-Dlq/5LAZgF0Gaz6yiqZCf6VCcZs1ghAJyrsu84Q/GT0gV+mCxbfmKNoGRKBYMJ8IEdGPqu49YWXD02GCknEDkw==",
+      "license": "MIT",
+      "dependencies": {
+        "scheduler": "^0.26.0"
+      },
+      "peerDependencies": {
+        "react": "^19.1.1"
+      }
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.52.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.52.2.tgz",
+      "integrity": "sha512-I25/2QgoROE1vYV+NQ1En9T9UFB9Cmfm2CJ83zZOlaDpvz29wGQSZXWKw7MiNXau7wYgB/T9fVIdIuEQ+KbiiA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.52.2",
+        "@rollup/rollup-android-arm64": "4.52.2",
+        "@rollup/rollup-darwin-arm64": "4.52.2",
+        "@rollup/rollup-darwin-x64": "4.52.2",
+        "@rollup/rollup-freebsd-arm64": "4.52.2",
+        "@rollup/rollup-freebsd-x64": "4.52.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.52.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.52.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.52.2",
+        "@rollup/rollup-linux-arm64-musl": "4.52.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.52.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.52.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.52.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-gnu": "4.52.2",
+        "@rollup/rollup-linux-x64-musl": "4.52.2",
+        "@rollup/rollup-openharmony-arm64": "4.52.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.52.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.52.2",
+        "@rollup/rollup-win32-x64-gnu": "4.52.2",
+        "@rollup/rollup-win32-x64-msvc": "4.52.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.26.0.tgz",
+      "integrity": "sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==",
+      "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.15",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
+      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.3"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
+      "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.3.tgz",
+      "integrity": "sha512-UxhIZQ+QInVdunkDAaiazvvT/+fXL5Osr0JZlJulepYu6Jd7qJtDZjlur0emRlT71EN3ScPoE7gvsuIKKNavKw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.3.6",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.3.6.tgz",
+      "integrity": "sha512-0msEVHJEScQbhkbVTb/4iHZdJ6SXp/AvxL2sjwYQFfBqleHtnCqv1J3sa9zbWz/6kW1m9Tfzn92vW+kZ1WV6QA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "vocalstudio",
+  "version": "1.0.0",
+  "description": "vocalstudio – vocal-focused audio production web app",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview"
+  },
+  "keywords": ["audio", "production", "web"],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.4",
+    "@types/react-dom": "^19.1.5",
+    "@vitejs/plugin-react": "^4.5.3",
+    "typescript": "^5.9.2",
+    "vite": "^6.0.5"
+  }
+}

--- a/src/App.css
+++ b/src/App.css
@@ -1,0 +1,558 @@
+
+.app-shell {
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 2.5rem 2rem 4rem;
+  color: #f5f5f5;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+}
+
+.app-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 2rem;
+  padding: 1.5rem 2rem;
+  background: linear-gradient(135deg, rgba(255, 48, 64, 0.18), rgba(12, 12, 14, 0.92));
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 48, 64, 0.35);
+  box-shadow: 0 20px 50px rgba(0, 0, 0, 0.4);
+}
+
+.app-header h1 {
+  margin: 0 0 0.5rem;
+  font-size: 2.25rem;
+  letter-spacing: -0.02em;
+}
+
+.app-header p {
+  margin: 0;
+  opacity: 0.9;
+  max-width: 48ch;
+}
+
+button {
+  cursor: pointer;
+  border-radius: 999px;
+  padding: 0.75rem 1.6rem;
+  font-weight: 600;
+  font-size: 1rem;
+  background: #1b1b1f;
+  color: #f5f5f5;
+  border: 1px solid #2c2c30;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
+button:hover:not(:disabled) {
+  transform: translateY(-1px);
+  box-shadow: 0 14px 30px rgba(0, 0, 0, 0.45);
+  border-color: rgba(255, 48, 64, 0.6);
+}
+
+button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+}
+
+button.primary {
+  background: linear-gradient(135deg, #ff1f4b, #b50824);
+  color: #ffffff;
+  border-color: rgba(255, 48, 64, 0.8);
+  box-shadow: 0 16px 40px rgba(255, 48, 64, 0.35);
+}
+
+button.accent {
+  background: linear-gradient(135deg, #303033, #1c1c1f);
+  color: #f5f5f5;
+}
+
+button.danger {
+  background: linear-gradient(135deg, #8f0f1f, #4b070c);
+  color: #ffffff;
+  border-color: rgba(255, 48, 64, 0.65);
+  box-shadow: 0 10px 32px rgba(255, 48, 64, 0.3);
+}
+
+
+.dropzone {
+  border: 2px dashed rgba(255, 48, 64, 0.35);
+  border-radius: 1.5rem;
+  padding: 2.5rem;
+  text-align: center;
+  background: rgba(10, 10, 12, 0.85);
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.dropzone:hover {
+  border-color: rgba(255, 48, 64, 0.7);
+  background: rgba(15, 15, 18, 0.9);
+}
+
+.dropzone-title {
+  margin: 0;
+  font-size: 1.35rem;
+  font-weight: 600;
+}
+
+.dropzone-subtitle {
+  margin: 0.35rem 0 0;
+  opacity: 0.7;
+}
+
+.track-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: rgba(14, 14, 16, 0.95);
+  border-radius: 1.5rem;
+  padding: 1.75rem 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(255, 48, 64, 0.05);
+}
+
+.track-section header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1.5rem;
+}
+
+.track-section header h2 {
+  margin: 0 0 0.25rem;
+}
+
+.track-section header p {
+  margin: 0;
+  opacity: 0.75;
+}
+
+.track-status {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0.85rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.05);
+  font-size: 0.85rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+
+.status-indicator {
+  display: inline-block;
+  width: 0.6rem;
+  height: 0.6rem;
+  border-radius: 50%;
+  background: #5c5c60;
+  box-shadow: 0 0 0 4px rgba(255, 255, 255, 0.05);
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.status-indicator.active {
+  background: #ff1f4b;
+  box-shadow: 0 0 0 4px rgba(255, 31, 75, 0.25);
+}
+
+.track-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.track-editor {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  background: rgba(12, 12, 14, 0.92);
+  border-radius: 1.5rem;
+  padding: 1.75rem 2rem 2rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(255, 31, 75, 0.06);
+}
+
+.track-editor__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 2rem;
+}
+
+.track-editor__header h2 {
+  margin: 0 0 0.4rem;
+}
+
+.track-editor__header p {
+  margin: 0;
+  opacity: 0.75;
+  max-width: 48ch;
+}
+
+.track-editor__meta {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.4rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(245, 245, 245, 0.75);
+}
+
+.track-editor__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.25rem;
+}
+
+.track-lane {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: rgba(20, 20, 22, 0.85);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  box-shadow: 0 18px 38px rgba(0, 0, 0, 0.4);
+  padding: 1.35rem 1.5rem;
+  position: relative;
+  overflow: hidden;
+}
+
+.track-lane--active {
+  border-color: rgba(255, 48, 64, 0.4);
+}
+
+.track-lane--recording {
+  box-shadow: 0 18px 42px rgba(255, 48, 64, 0.22);
+}
+
+.track-lane__info {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.track-lane__label {
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: rgba(255, 255, 255, 0.55);
+}
+
+.track-lane__duration {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.track-lane__body {
+  position: relative;
+  border-radius: 1rem;
+  background: rgba(10, 10, 12, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.04);
+  padding: 1.2rem 1rem;
+  overflow: hidden;
+}
+
+.track-lane__grid {
+  position: absolute;
+  inset: 0.75rem 0.5rem;
+  pointer-events: none;
+}
+
+.track-lane__grid-line {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  width: 1px;
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.track-lane__grid-line--strong {
+  background: rgba(255, 48, 64, 0.45);
+  box-shadow: 0 0 12px rgba(255, 48, 64, 0.25);
+}
+
+.track-waveform {
+  position: relative;
+  z-index: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.track-waveform__bars {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(2px, 1fr));
+  align-items: center;
+  gap: 4px;
+  width: 100%;
+  height: 120px;
+}
+
+.track-waveform__bars span {
+  display: block;
+  width: 100%;
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.85), rgba(255, 48, 64, 0.65));
+  border-radius: 999px;
+  min-height: 8px;
+}
+
+.track-waveform--beat .track-waveform__bars span {
+  background: linear-gradient(180deg, rgba(255, 255, 255, 0.65), rgba(200, 200, 205, 0.45));
+}
+
+.track-waveform--vocal .track-waveform__bars span {
+  background: linear-gradient(180deg, rgba(255, 48, 64, 0.8), rgba(98, 9, 20, 0.85));
+}
+
+.track-waveform__placeholder {
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.55);
+  padding: 2.5rem 0;
+  text-align: center;
+  width: 100%;
+}
+
+.track-lane__overlay {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  background: rgba(12, 12, 14, 0.85);
+  border: 1px solid rgba(255, 255, 255, 0.08);
+  border-radius: 0.85rem;
+  padding: 0.6rem 0.9rem;
+  font-size: 0.85rem;
+  color: rgba(255, 255, 255, 0.8);
+  box-shadow: 0 10px 24px rgba(0, 0, 0, 0.45);
+}
+
+.track-card {
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  background: rgba(11, 11, 13, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  position: relative;
+  overflow: hidden;
+}
+
+.tempo-readout {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.tempo-readout strong {
+  font-size: 1rem;
+  font-weight: 600;
+  text-transform: none;
+  opacity: 1;
+}
+
+.track-card::after {
+  content: '';
+  position: absolute;
+  inset: 0;
+  opacity: 0;
+  transition: opacity 0.2s ease;
+  background: linear-gradient(135deg, rgba(255, 31, 75, 0.15), transparent 60%);
+}
+
+.track-card--ready::after,
+.track-card--armed::after {
+  opacity: 1;
+}
+
+.track-card--armed {
+  border-color: rgba(255, 31, 75, 0.5);
+}
+
+.track-card--ready {
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.track-card--pending {
+  border-style: dashed;
+  border-color: rgba(255, 255, 255, 0.08);
+}
+
+.track-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.track-label {
+  font-size: 0.8rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  opacity: 0.6;
+}
+
+.track-details {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  opacity: 0.75;
+}
+
+.track-progress {
+  background: rgba(255, 255, 255, 0.05);
+  height: 0.45rem;
+  border-radius: 999px;
+  overflow: hidden;
+}
+
+.track-progress span {
+  display: block;
+  height: 100%;
+  background: linear-gradient(90deg, rgba(255, 48, 64, 0.8), rgba(255, 48, 64, 0.4));
+  border-radius: inherit;
+}
+
+.beat-summary {
+  margin-top: 1.25rem;
+  display: inline-flex;
+  gap: 1rem;
+  align-items: center;
+  background: rgba(255, 255, 255, 0.05);
+  padding: 0.6rem 1.2rem;
+  border-radius: 999px;
+  font-size: 0.95rem;
+}
+
+
+.transport {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  padding: 1.5rem;
+  border-radius: 1.25rem;
+  background: rgba(12, 12, 14, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  box-shadow: inset 0 0 0 1px rgba(255, 48, 64, 0.08);
+}
+
+
+.timeline {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  background: rgba(11, 11, 13, 0.92);
+  border-radius: 1.25rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.timeline h3 {
+  margin: 0 0 0.35rem;
+  font-size: 0.85rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.timeline span {
+  font-size: 1.1rem;
+}
+
+.timeline span strong {
+  font-weight: 600;
+}
+
+.status-message {
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.effects-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+}
+
+.module {
+  background: rgba(15, 15, 18, 0.95);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 48, 64, 0.04);
+}
+
+.module header h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.25rem;
+}
+
+.module header p {
+  margin: 0;
+  opacity: 0.7;
+  font-size: 0.9rem;
+}
+
+.module-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.module-split {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 1.25rem;
+}
+
+.module-body h3 {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+
+.notifications {
+  padding: 1rem 1.5rem;
+  background: rgba(11, 11, 13, 0.92);
+  border: 1px solid rgba(255, 255, 255, 0.06);
+  border-radius: 1.25rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 48, 64, 0.04);
+}
+
+.notifications p {
+  margin: 0;
+}
+
+.notifications .error {
+  color: #ff6b81;
+}
+
+@media (max-width: 768px) {
+  .app-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+
+  button {
+    width: 100%;
+  }
+
+  .transport {
+    justify-content: center;
+  }
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,0 +1,759 @@
+import { ChangeEvent, DragEvent, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import AudioEngine, {
+  CompressorSettings,
+  DelaySettings,
+  EQSettings,
+  BeatAnalysis,
+  ReverbSettings,
+  PlaybackAlignment,
+  VolumeSettings
+} from './audio/AudioEngine';
+import SliderControl from './components/SliderControl';
+import './App.css';
+
+const defaultVolumes: VolumeSettings = {
+  beat: 0.85,
+  vocal: 1,
+  master: 0.9
+};
+
+const defaultEQ: EQSettings = {
+  low: 0,
+  mid: 0,
+  high: 0
+};
+
+const defaultCompressor: CompressorSettings = {
+  threshold: -18,
+  knee: 30,
+  ratio: 3,
+  attack: 0.003,
+  release: 0.25
+};
+
+const defaultDelay: DelaySettings = {
+  time: 0.28,
+  feedback: 0.35,
+  mix: 0.25
+};
+
+const defaultReverb: ReverbSettings = {
+  duration: 2.5,
+  decay: 2.2,
+  mix: 0.3
+};
+
+const formatDuration = (duration: number | null) => {
+  if (!duration) return '0:00';
+  const minutes = Math.floor(duration / 60);
+  const seconds = Math.round(duration % 60)
+    .toString()
+    .padStart(2, '0');
+  return `${minutes}:${seconds}`;
+};
+
+function App() {
+  const engineRef = useRef<AudioEngine | null>(null);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  const [volumes, setVolumes] = useState(defaultVolumes);
+  const [eqSettings, setEqSettings] = useState(defaultEQ);
+  const [compressor, setCompressor] = useState(defaultCompressor);
+  const [delaySettings, setDelaySettings] = useState(defaultDelay);
+  const [reverbSettings, setReverbSettings] = useState(defaultReverb);
+
+  const [beatName, setBeatName] = useState<string>('');
+  const [beatDuration, setBeatDuration] = useState<number | null>(null);
+  const [beatTempo, setBeatTempo] = useState<number | null>(null);
+  const [downbeatOffset, setDownbeatOffset] = useState<number | null>(null);
+  const [vocalDuration, setVocalDuration] = useState<number | null>(null);
+  const [alignmentShift, setAlignmentShift] = useState<number | null>(null);
+  const [alignmentTarget, setAlignmentTarget] = useState<number | null>(null);
+  const [beatWaveform, setBeatWaveform] = useState<number[] | null>(null);
+  const [vocalWaveform, setVocalWaveform] = useState<number[] | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string>('Drop in your beat to get started.');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [isRecording, setIsRecording] = useState(false);
+  const [isExporting, setIsExporting] = useState(false);
+
+  useEffect(() => {
+    const engine = new AudioEngine();
+    engineRef.current = engine;
+    engine.initialize().catch((error) => {
+      console.error(error);
+      setErrorMessage('Failed to initialise audio engine. Please refresh the page.');
+    });
+    engine.onPlaybackStateChange = setIsPlaying;
+    engine.onRecordingStateChange = setIsRecording;
+    engine.onVocalUpdated = (duration) => {
+      setVocalDuration(duration);
+      setVocalWaveform(engine.getVocalWaveform());
+      if (duration) {
+        setStatusMessage('Vocal take captured. Dial in the mix and master the bounce.');
+      } else {
+        setStatusMessage('Vocal take cleared. Ready when you are.');
+      }
+    };
+
+    return () => {
+      engine.dispose();
+    };
+  }, []);
+
+  const handleBeatLoad = useCallback(
+    async (file: File) => {
+      if (!engineRef.current) return;
+      setErrorMessage(null);
+      try {
+        setStatusMessage('Loading beat...');
+        const analysis: BeatAnalysis = await engineRef.current.loadBeat(file);
+        setBeatDuration(analysis.duration);
+        setBeatTempo(analysis.tempo);
+        setDownbeatOffset(analysis.downbeatOffset);
+        setAlignmentShift(null);
+        setAlignmentTarget(null);
+        setBeatName(file.name);
+        setBeatWaveform(engineRef.current?.getBeatWaveform() ?? null);
+        setStatusMessage(
+          analysis.tempo
+            ? `Beat ready. Tempo locked at ${analysis.tempo.toFixed(1)} BPM.`
+            : 'Beat ready. Set your levels and record when you are inspired.'
+        );
+      } catch (error) {
+        console.error(error);
+        setErrorMessage('Could not load the beat. Please try a different file.');
+        setStatusMessage('Drop in your beat to get started.');
+        setBeatTempo(null);
+        setDownbeatOffset(null);
+        setBeatWaveform(null);
+      }
+    },
+    []
+  );
+
+  const isAudioFile = useCallback((file: File) => {
+    if (file.type.startsWith('audio')) {
+      return true;
+    }
+
+    const audioExtensions = ['.wav', '.mp3', '.flac', '.aiff', '.aac', '.ogg', '.m4a', '.webm'];
+    const lowerName = file.name.toLowerCase();
+    return audioExtensions.some((extension) => lowerName.endsWith(extension));
+  }, []);
+
+  const handleDrop = useCallback(
+    (event: DragEvent<HTMLDivElement>) => {
+      event.preventDefault();
+      const file = event.dataTransfer.files?.[0];
+      if (file && isAudioFile(file)) {
+        void handleBeatLoad(file);
+      } else {
+        setErrorMessage('Unsupported file. Please drop an audio file.');
+      }
+    },
+    [handleBeatLoad, isAudioFile]
+  );
+
+  const handleFileInput = useCallback(
+    (event: ChangeEvent<HTMLInputElement>) => {
+      const file = event.target.files?.[0];
+      if (file) {
+        if (!isAudioFile(file)) {
+          setErrorMessage('Unsupported file. Please choose an audio file.');
+          return;
+        }
+        void handleBeatLoad(file);
+      }
+    },
+    [handleBeatLoad, isAudioFile]
+  );
+
+  const handlePlay = useCallback(async () => {
+    if (!engineRef.current) return;
+    setErrorMessage(null);
+    try {
+      const alignment: PlaybackAlignment = await engineRef.current.startPlayback();
+      setAlignmentShift(alignment.alignmentShift);
+      setAlignmentTarget(alignment.quantizedTarget);
+      if (alignment.alignmentShift !== null) {
+        const shiftMs = Math.round(alignment.alignmentShift * 1000);
+        if (shiftMs === 0) {
+          setStatusMessage('Playback rolling. Vocal take already locked to the grid.');
+        } else if (shiftMs > 0) {
+          setStatusMessage(
+            `Playback rolling. Vocal pushed forward ${shiftMs}ms to flow with the beat.`
+          );
+        } else {
+          setStatusMessage(
+            `Playback rolling. Vocal pulled back ${Math.abs(shiftMs)}ms to stay on beat.`
+          );
+        }
+      } else {
+        setStatusMessage('Playback rolling. Adjust effects in real time.');
+      }
+    } catch (error) {
+      console.error(error);
+      setErrorMessage((error as Error).message);
+    }
+  }, []);
+
+  const handleStop = useCallback(() => {
+    engineRef.current?.stopPlayback();
+    setStatusMessage('Playback stopped. Ready for adjustments.');
+    setAlignmentShift(null);
+    setAlignmentTarget(null);
+  }, []);
+
+  const handleRecordToggle = useCallback(async () => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    setErrorMessage(null);
+    try {
+      if (engine.isRecording) {
+        await engine.stopRecording();
+        setStatusMessage('Recording stopped. Review your take.');
+        setAlignmentShift(null);
+        setAlignmentTarget(null);
+      } else {
+        if (engine.beatDuration) {
+          await engine.startPlayback();
+        }
+        await engine.startRecording();
+        setStatusMessage('Recording vocals. Deliver your best take.');
+      }
+    } catch (error) {
+      console.error(error);
+      setErrorMessage('Recording failed. Check microphone permissions and try again.');
+    }
+  }, []);
+
+  const handleExport = useCallback(async () => {
+    const engine = engineRef.current;
+    if (!engine) return;
+    setErrorMessage(null);
+    if (isExporting) return;
+    try {
+      setIsExporting(true);
+      setStatusMessage('Rendering your master...');
+      const blob = await engine.exportMix();
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = 'viveye-master.webm';
+      anchor.click();
+      URL.revokeObjectURL(url);
+      setStatusMessage('Master exported. Share it with the world.');
+    } catch (error) {
+      console.error(error);
+      setErrorMessage((error as Error).message);
+    } finally {
+      setIsExporting(false);
+    }
+  }, [isExporting]);
+
+  const clearVocal = useCallback(() => {
+    engineRef.current?.clearVocalTake();
+    setAlignmentShift(null);
+    setAlignmentTarget(null);
+    setVocalWaveform(null);
+  }, []);
+
+  useEffect(() => {
+    engineRef.current?.setVolumeSettings(volumes);
+  }, [volumes]);
+
+  useEffect(() => {
+    engineRef.current?.setEQSettings(eqSettings);
+  }, [eqSettings]);
+
+  useEffect(() => {
+    engineRef.current?.setCompressorSettings(compressor);
+  }, [compressor]);
+
+  useEffect(() => {
+    engineRef.current?.setDelaySettings(delaySettings);
+  }, [delaySettings]);
+
+  useEffect(() => {
+    engineRef.current?.setReverbSettings(reverbSettings);
+  }, [reverbSettings]);
+
+  const beatGridMarkers = useMemo(() => {
+    if (beatTempo && beatDuration) {
+      const beatLength = 60 / beatTempo;
+      const totalBeats = Math.ceil(beatDuration / beatLength);
+      const clamped = Math.min(64, Math.max(8, totalBeats));
+      return Array.from({ length: clamped }, (_, index) => index);
+    }
+    return Array.from({ length: 16 }, (_, index) => index);
+  }, [beatDuration, beatTempo]);
+
+  const renderWaveform = useCallback(
+    (data: number[] | null, placeholder: string) => {
+      if (!data || data.length === 0) {
+        return <div className="track-waveform__placeholder">{placeholder}</div>;
+      }
+      return (
+        <div className="track-waveform__bars">
+          {data.map((value, index) => (
+            <span key={index} style={{ height: `${Math.max(8, value * 100)}%` }} />
+          ))}
+        </div>
+      );
+    },
+    []
+  );
+
+  const effectControls = useMemo(
+    () => (
+      <div className="effects-grid">
+        <section className="module">
+          <header>
+            <h2>Balance</h2>
+            <p>Blend the beat and vocal capture to sit the performance correctly.</p>
+          </header>
+          <div className="module-body">
+            <SliderControl
+              label="Beat Level"
+              value={volumes.beat}
+              min={0}
+              max={2}
+              step={0.01}
+              onChange={(value) => setVolumes((prev) => ({ ...prev, beat: value }))}
+            />
+            <SliderControl
+              label="Vocal Level"
+              value={volumes.vocal}
+              min={0}
+              max={2}
+              step={0.01}
+              onChange={(value) => setVolumes((prev) => ({ ...prev, vocal: value }))}
+            />
+            <SliderControl
+              label="Master Output"
+              value={volumes.master}
+              min={0}
+              max={2}
+              step={0.01}
+              onChange={(value) => setVolumes((prev) => ({ ...prev, master: value }))}
+            />
+          </div>
+        </section>
+
+        <section className="module">
+          <header>
+            <h2>Tone Sculpting</h2>
+            <p>Shape the vocal to sit in the mix and leave the beat breathing.</p>
+          </header>
+          <div className="module-body">
+            <SliderControl
+              label="Low Shelf (dB)"
+              value={eqSettings.low}
+              min={-12}
+              max={12}
+              step={0.5}
+              onChange={(value) => setEqSettings((prev) => ({ ...prev, low: value }))}
+            />
+            <SliderControl
+              label="Presence (dB)"
+              value={eqSettings.mid}
+              min={-12}
+              max={12}
+              step={0.5}
+              onChange={(value) => setEqSettings((prev) => ({ ...prev, mid: value }))}
+            />
+            <SliderControl
+              label="Air (dB)"
+              value={eqSettings.high}
+              min={-12}
+              max={12}
+              step={0.5}
+              onChange={(value) => setEqSettings((prev) => ({ ...prev, high: value }))}
+            />
+          </div>
+        </section>
+
+        <section className="module">
+          <header>
+            <h2>Dynamics</h2>
+            <p>Keep takes controlled and polished with transparent compression.</p>
+          </header>
+          <div className="module-body">
+            <SliderControl
+              label="Threshold (dB)"
+              value={compressor.threshold}
+              min={-60}
+              max={0}
+              step={1}
+              onChange={(value) => setCompressor((prev) => ({ ...prev, threshold: value }))}
+            />
+            <SliderControl
+              label="Ratio"
+              value={compressor.ratio}
+              min={1}
+              max={12}
+              step={0.1}
+              onChange={(value) => setCompressor((prev) => ({ ...prev, ratio: value }))}
+            />
+            <SliderControl
+              label="Attack (s)"
+              value={compressor.attack}
+              min={0.001}
+              max={0.1}
+              step={0.001}
+              onChange={(value) => setCompressor((prev) => ({ ...prev, attack: value }))}
+            />
+            <SliderControl
+              label="Release (s)"
+              value={compressor.release}
+              min={0.05}
+              max={1}
+              step={0.01}
+              onChange={(value) => setCompressor((prev) => ({ ...prev, release: value }))}
+            />
+          </div>
+        </section>
+
+        <section className="module">
+          <header>
+            <h2>Space &amp; Depth</h2>
+            <p>Add delay and reverb to taste for movement and atmosphere.</p>
+          </header>
+          <div className="module-split">
+            <div className="module-body">
+              <h3>Delay</h3>
+              <SliderControl
+                label="Time (s)"
+                value={delaySettings.time}
+                min={0}
+                max={0.9}
+                step={0.01}
+                onChange={(value) => setDelaySettings((prev) => ({ ...prev, time: value }))}
+              />
+              <SliderControl
+                label="Feedback"
+                value={delaySettings.feedback}
+                min={0}
+                max={0.9}
+                step={0.01}
+                onChange={(value) => setDelaySettings((prev) => ({ ...prev, feedback: value }))}
+              />
+              <SliderControl
+                label="Mix"
+                value={delaySettings.mix}
+                min={0}
+                max={1}
+                step={0.01}
+                onChange={(value) => setDelaySettings((prev) => ({ ...prev, mix: value }))}
+              />
+            </div>
+            <div className="module-body">
+              <h3>Reverb</h3>
+              <SliderControl
+                label="Length (s)"
+                value={reverbSettings.duration}
+                min={0.5}
+                max={6}
+                step={0.1}
+                onChange={(value) => setReverbSettings((prev) => ({ ...prev, duration: value }))}
+              />
+              <SliderControl
+                label="Decay"
+                value={reverbSettings.decay}
+                min={0.5}
+                max={4}
+                step={0.1}
+                onChange={(value) => setReverbSettings((prev) => ({ ...prev, decay: value }))}
+              />
+              <SliderControl
+                label="Mix"
+                value={reverbSettings.mix}
+                min={0}
+                max={1}
+                step={0.01}
+                onChange={(value) => setReverbSettings((prev) => ({ ...prev, mix: value }))}
+              />
+            </div>
+          </div>
+        </section>
+      </div>
+    ),
+    [compressor, delaySettings, eqSettings, reverbSettings, volumes]
+  );
+
+  return (
+    <div className="app-shell">
+      <header className="app-header">
+        <div>
+          <h1>vocalstudio</h1>
+          <p>
+            Purpose-built for vocalists who already have the beat. Capture, enhance, and master with
+            studio-grade processing.
+          </p>
+        </div>
+        <button
+          type="button"
+          className="primary"
+          onClick={() => fileInputRef.current?.click()}
+        >
+          Import Beat
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          accept="audio/*"
+          hidden
+          onChange={handleFileInput}
+        />
+      </header>
+
+      <main>
+        <section
+          className="dropzone"
+          onDragOver={(event) => event.preventDefault()}
+          onDrop={handleDrop}
+        >
+          <p className="dropzone-title">Drag &amp; drop your beat</p>
+          <p className="dropzone-subtitle">WAV, MP3, FLAC and more are supported.</p>
+          {beatName && (
+            <div className="beat-summary">
+              <strong>{beatName}</strong>
+              <span>{formatDuration(beatDuration)}</span>
+            </div>
+          )}
+        </section>
+
+        <section className="track-section">
+          <header>
+            <div>
+              <h2>Tracks</h2>
+              <p>Balance your imported beat and captured vocals before fine-tuning the mix.</p>
+            </div>
+            <div className="track-status">
+              <span className={`status-indicator ${isPlaying ? 'active' : ''}`}></span>
+              <span>{isPlaying ? 'Playback running' : 'Playback idle'}</span>
+            </div>
+          </header>
+          <div className="track-grid">
+            <div className={`track-card ${beatName ? 'track-card--ready' : 'track-card--pending'}`}>
+              <div className="track-meta">
+                <span className="track-label">Beat</span>
+                <strong>{beatName || 'Waiting for beat import'}</strong>
+              </div>
+              <div className="track-details">
+                <span>{beatDuration ? formatDuration(beatDuration) : '—:—'}</span>
+                <span>{isPlaying ? 'In the mix' : 'Standing by'}</span>
+              </div>
+              <div className="tempo-readout">
+                <span>Tempo</span>
+                <strong>{beatTempo ? `${beatTempo.toFixed(1)} BPM` : 'Analyzing…'}</strong>
+              </div>
+              <div className="track-progress">
+                <span style={{ width: beatDuration ? '100%' : '35%' }}></span>
+              </div>
+            </div>
+            <div
+              className={`track-card ${
+                vocalDuration ? 'track-card--ready' : isRecording ? 'track-card--armed' : 'track-card--pending'
+              }`}
+            >
+              <div className="track-meta">
+                <span className="track-label">Vocal</span>
+                <strong>
+                  {isRecording
+                    ? 'Recording in progress'
+                    : vocalDuration
+                    ? `${formatDuration(vocalDuration)} captured`
+                    : 'Ready to record'}
+                </strong>
+              </div>
+              <div className="track-details">
+                <span>{vocalDuration ? formatDuration(vocalDuration) : '—:—'}</span>
+                <span>{isRecording ? 'Armed' : vocalDuration ? 'Take stored' : 'Standby'}</span>
+              </div>
+              <div className="tempo-readout">
+                <span>Alignment</span>
+                <strong>
+                  {alignmentShift === null
+                    ? 'Waiting for playback'
+                    : alignmentShift === 0
+                    ? 'Locked to grid'
+                    : alignmentShift > 0
+                    ? `+${Math.round(alignmentShift * 1000)}ms`
+                    : `${Math.round(alignmentShift * 1000)}ms`}
+                </strong>
+              </div>
+              <div className="track-progress">
+                <span style={{ width: vocalDuration ? '100%' : isRecording ? '60%' : '25%' }}></span>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="track-editor">
+          <div className="track-editor__header">
+            <div>
+              <h2>Track Editor</h2>
+              <p>Line up vocals with the imported beat and keep the groove intact.</p>
+            </div>
+            <div className="track-editor__meta">
+              <span>{beatTempo ? `${beatTempo.toFixed(1)} BPM` : 'Tempo pending'}</span>
+              <span>{beatDuration ? formatDuration(beatDuration) : '—:—'}</span>
+            </div>
+          </div>
+          <div className="track-editor__grid">
+            <div className="track-lane">
+              <div className="track-lane__info">
+                <span className="track-lane__label">Beat</span>
+                <strong>{beatName || 'Waiting for beat import'}</strong>
+                <span className="track-lane__duration">{beatDuration ? formatDuration(beatDuration) : '—:—'}</span>
+              </div>
+              <div className="track-lane__body">
+                <div className="track-lane__grid">
+                  {beatGridMarkers.map((marker) => (
+                    <span
+                      key={`beat-marker-${marker}`}
+                      className={`track-lane__grid-line${
+                        marker % 4 === 0 ? ' track-lane__grid-line--strong' : ''
+                      }`}
+                      style={{
+                        left: `${(marker / Math.max(1, beatGridMarkers.length - 1)) * 100}%`
+                      }}
+                    />
+                  ))}
+                </div>
+                <div className="track-waveform track-waveform--beat">
+                  {renderWaveform(beatWaveform, 'Awaiting beat import')}
+                </div>
+              </div>
+            </div>
+            <div
+              className={`track-lane ${vocalDuration ? 'track-lane--active' : ''} ${
+                isRecording ? 'track-lane--recording' : ''
+              }`}
+            >
+              <div className="track-lane__info">
+                <span className="track-lane__label">Vocal</span>
+                <strong>
+                  {isRecording
+                    ? 'Recording…'
+                    : vocalDuration
+                    ? `${formatDuration(vocalDuration)} captured`
+                    : 'No take captured'}
+                </strong>
+                <span className="track-lane__duration">
+                  {vocalDuration ? formatDuration(vocalDuration) : isRecording ? '● rec' : '—:—'}
+                </span>
+              </div>
+              <div className="track-lane__body">
+                <div className="track-lane__grid">
+                  {beatGridMarkers.map((marker) => (
+                    <span
+                      key={`vocal-marker-${marker}`}
+                      className={`track-lane__grid-line${
+                        marker % 4 === 0 ? ' track-lane__grid-line--strong' : ''
+                      }`}
+                      style={{
+                        left: `${(marker / Math.max(1, beatGridMarkers.length - 1)) * 100}%`
+                      }}
+                    />
+                  ))}
+                </div>
+                <div className="track-waveform track-waveform--vocal">
+                  {renderWaveform(
+                    vocalWaveform,
+                    isRecording ? 'Capturing take…' : 'Record vocals to populate the lane'
+                  )}
+                </div>
+                {alignmentTarget !== null && (
+                  <div className="track-lane__overlay">
+                    <span>Quantized start {alignmentTarget.toFixed(2)}s</span>
+                    <span>
+                      {alignmentShift === null || alignmentShift === 0
+                        ? 'Locked to grid'
+                        : alignmentShift > 0
+                        ? `Shifted +${Math.round(alignmentShift * 1000)}ms`
+                        : `Shifted ${Math.round(alignmentShift * 1000)}ms`}
+                    </span>
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+
+        <section className="transport">
+          <button type="button" onClick={handlePlay} disabled={isRecording}>
+            Play
+          </button>
+          <button type="button" onClick={handleStop}>
+            Stop
+          </button>
+          <button
+            type="button"
+            className={isRecording ? 'danger' : 'accent'}
+            onClick={handleRecordToggle}
+          >
+            {isRecording ? 'Stop Recording' : 'Record'}
+          </button>
+          <button
+            type="button"
+            onClick={handleExport}
+            disabled={isExporting}
+          >
+            {isExporting ? 'Rendering…' : 'Export Master'}
+          </button>
+          <button type="button" onClick={clearVocal} disabled={!vocalDuration}>
+            Clear Vocal Take
+          </button>
+        </section>
+
+        <section className="timeline">
+          <div>
+            <h3>Beat</h3>
+            <span>{formatDuration(beatDuration)}</span>
+          </div>
+          <div>
+            <h3>Vocal Take</h3>
+            <span>{formatDuration(vocalDuration)}</span>
+          </div>
+          <div>
+            <h3>Grid</h3>
+            <span>
+              {beatTempo
+                ? `${beatTempo.toFixed(1)} BPM${
+                    downbeatOffset !== null ? ` • Downbeat @ ${downbeatOffset.toFixed(2)}s` : ''
+                  }`
+                : 'Tempo analysis unavailable'}
+            </span>
+          </div>
+          <div>
+            <h3>Vocal Sync</h3>
+            <span>
+              {alignmentTarget !== null
+                ? `Quantized start ${alignmentTarget.toFixed(2)}s${
+                    alignmentShift !== null
+                      ? ` • Shift ${alignmentShift > 0 ? '+' : ''}${Math.round(alignmentShift * 1000)}ms`
+                      : ''
+                  }`
+                : 'Awaiting playback alignment'}
+            </span>
+          </div>
+          <div>
+            <h3>Status</h3>
+            <span className="status-message">{statusMessage}</span>
+          </div>
+        </section>
+
+        {effectControls}
+      </main>
+
+      <footer className="notifications">
+        {errorMessage ? <p className="error">{errorMessage}</p> : <p>{statusMessage}</p>}
+      </footer>
+    </div>
+  );
+}
+
+export default App;

--- a/src/audio/AudioEngine.ts
+++ b/src/audio/AudioEngine.ts
@@ -1,0 +1,900 @@
+/* eslint-disable no-underscore-dangle */
+export type EQSettings = {
+  low: number;
+  mid: number;
+  high: number;
+};
+
+export type CompressorSettings = {
+  threshold: number;
+  knee: number;
+  ratio: number;
+  attack: number;
+  release: number;
+};
+
+export type DelaySettings = {
+  time: number;
+  feedback: number;
+  mix: number;
+};
+
+export type ReverbSettings = {
+  duration: number;
+  decay: number;
+  mix: number;
+};
+
+export type VolumeSettings = {
+  beat: number;
+  vocal: number;
+  master: number;
+};
+
+type PlaybackStateListener = (isPlaying: boolean) => void;
+type RecordingStateListener = (isRecording: boolean) => void;
+type VocalUpdatedListener = (duration: number | null) => void;
+
+export type BeatAnalysis = {
+  duration: number;
+  tempo: number | null;
+  downbeatOffset: number | null;
+};
+
+export type PlaybackAlignment = {
+  alignmentShift: number | null;
+  quantizedTarget: number | null;
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(max, Math.max(min, value));
+
+export class AudioEngine {
+  private context: AudioContext | null = null;
+
+  private beatBuffer: AudioBuffer | null = null;
+
+  private vocalBuffer: AudioBuffer | null = null;
+
+  private beatGain!: GainNode;
+
+  private vocalGain!: GainNode;
+
+  private vocalChainInput!: GainNode;
+
+  private masterGain!: GainNode;
+
+  private masterDryGain!: GainNode;
+
+  private vocalPostGain!: GainNode;
+
+  private delayInput!: GainNode;
+
+  private delayWet!: GainNode;
+
+  private delayFeedback!: GainNode;
+
+  private delayNode!: DelayNode;
+
+  private reverbInput!: GainNode;
+
+  private reverbWet!: GainNode;
+
+  private convolver!: ConvolverNode;
+
+  private eqLow!: BiquadFilterNode;
+
+  private eqMid!: BiquadFilterNode;
+
+  private eqHigh!: BiquadFilterNode;
+
+  private compressor!: DynamicsCompressorNode;
+
+  private recordDestination!: MediaStreamAudioDestinationNode;
+
+  private currentBeatSource: AudioBufferSourceNode | null = null;
+
+  private currentVocalSource: AudioBufferSourceNode | null = null;
+
+  private micStream: MediaStream | null = null;
+
+  private micSource: MediaStreamAudioSourceNode | null = null;
+
+  private recorderNode: AudioWorkletNode | ScriptProcessorNode | null = null;
+
+  private recorderMonitor: GainNode | null = null;
+
+  private recordingChunks: Float32Array[][] = [];
+
+  private recordingLength = 0;
+
+  private recordingSampleRate = 44100;
+
+  private recordingChannelCount = 0;
+
+  private audioWorkletModuleLoaded = false;
+
+  private _isPlaying = false;
+
+  private _isRecording = false;
+
+  private reverbSettings: ReverbSettings = {
+    duration: 2.5,
+    decay: 2.2,
+    mix: 0.3
+  };
+
+  private delaySettings: DelaySettings = {
+    time: 0.28,
+    feedback: 0.35,
+    mix: 0.25
+  };
+
+  private eqSettings: EQSettings = {
+    low: 0,
+    mid: 0,
+    high: 0
+  };
+
+  private compressorSettings: CompressorSettings = {
+    threshold: -18,
+    knee: 30,
+    ratio: 3,
+    attack: 0.003,
+    release: 0.25
+  };
+
+  private volumeSettings: VolumeSettings = {
+    beat: 0.85,
+    vocal: 1,
+    master: 0.9
+  };
+
+  onPlaybackStateChange: PlaybackStateListener | null = null;
+
+  onRecordingStateChange: RecordingStateListener | null = null;
+
+  onVocalUpdated: VocalUpdatedListener | null = null;
+
+  private beatTempo: number | null = null;
+
+  private beatDownbeatOffset: number | null = null;
+
+  private vocalOnset: number | null = null;
+
+  private beatWaveform: number[] | null = null;
+
+  private vocalWaveform: number[] | null = null;
+
+  private lastAlignment: PlaybackAlignment = {
+    alignmentShift: null,
+    quantizedTarget: null
+  };
+
+  async initialize() {
+    if (this.context) return;
+    const context = new AudioContext();
+    this.context = context;
+    this.setupGraph(context);
+  }
+
+  private ensureContext(): AudioContext {
+    if (!this.context) {
+      throw new Error('Audio engine not initialised');
+    }
+    return this.context;
+  }
+
+  private setupGraph(context: AudioContext) {
+    this.masterGain = context.createGain();
+    this.masterGain.gain.value = this.volumeSettings.master;
+
+    this.recordDestination = context.createMediaStreamDestination();
+    this.masterGain.connect(context.destination);
+    this.masterGain.connect(this.recordDestination);
+
+    this.beatGain = context.createGain();
+    this.beatGain.gain.value = this.volumeSettings.beat;
+    this.beatGain.connect(this.masterGain);
+
+    this.vocalGain = context.createGain();
+    this.vocalGain.gain.value = this.volumeSettings.vocal;
+
+    this.vocalChainInput = context.createGain();
+    this.vocalGain.connect(this.vocalChainInput);
+
+    this.eqLow = context.createBiquadFilter();
+    this.eqLow.type = 'lowshelf';
+    this.eqLow.frequency.value = 120;
+    this.eqLow.gain.value = this.eqSettings.low;
+
+    this.eqMid = context.createBiquadFilter();
+    this.eqMid.type = 'peaking';
+    this.eqMid.frequency.value = 1800;
+    this.eqMid.Q.value = 1;
+    this.eqMid.gain.value = this.eqSettings.mid;
+
+    this.eqHigh = context.createBiquadFilter();
+    this.eqHigh.type = 'highshelf';
+    this.eqHigh.frequency.value = 8000;
+    this.eqHigh.gain.value = this.eqSettings.high;
+
+    this.compressor = context.createDynamicsCompressor();
+    this.updateCompressorNode();
+
+    this.vocalPostGain = context.createGain();
+    this.vocalPostGain.gain.value = 1;
+
+    this.masterDryGain = context.createGain();
+    this.masterDryGain.gain.value = this.computeDryGain();
+    this.masterDryGain.connect(this.masterGain);
+
+    this.delayInput = context.createGain();
+    this.delayNode = context.createDelay(1.5);
+    this.delayNode.delayTime.value = this.delaySettings.time;
+    this.delayFeedback = context.createGain();
+    this.delayFeedback.gain.value = this.delaySettings.feedback;
+    this.delayWet = context.createGain();
+    this.delayWet.gain.value = this.delaySettings.mix;
+
+    this.delayInput.connect(this.delayNode);
+    this.delayNode.connect(this.delayFeedback);
+    this.delayFeedback.connect(this.delayNode);
+    this.delayNode.connect(this.delayWet);
+    this.delayWet.connect(this.masterGain);
+
+    this.reverbInput = context.createGain();
+    this.reverbInput.gain.value = this.reverbSettings.mix;
+    this.convolver = context.createConvolver();
+    this.refreshReverbImpulse();
+    this.reverbWet = context.createGain();
+    this.reverbWet.gain.value = this.reverbSettings.mix;
+    this.reverbInput.connect(this.convolver);
+    this.convolver.connect(this.reverbWet);
+    this.reverbWet.connect(this.masterGain);
+
+    this.vocalChainInput.connect(this.eqLow);
+    this.eqLow.connect(this.eqMid);
+    this.eqMid.connect(this.eqHigh);
+    this.eqHigh.connect(this.compressor);
+    this.compressor.connect(this.vocalPostGain);
+    this.vocalPostGain.connect(this.masterDryGain);
+    this.vocalPostGain.connect(this.delayInput);
+    this.vocalPostGain.connect(this.reverbInput);
+  }
+
+  private refreshReverbImpulse() {
+    const context = this.ensureContext();
+    const { duration, decay } = this.reverbSettings;
+    const sampleRate = context.sampleRate;
+    const length = Math.floor(sampleRate * duration);
+    const impulse = context.createBuffer(2, length, sampleRate);
+    for (let channel = 0; channel < impulse.numberOfChannels; channel += 1) {
+      const impulseData = impulse.getChannelData(channel);
+      for (let i = 0; i < length; i += 1) {
+        impulseData[i] =
+          (Math.random() * 2 - 1) * Math.pow(1 - i / length, decay);
+      }
+    }
+    this.convolver.buffer = impulse;
+  }
+
+  private updateCompressorNode() {
+    if (!this.compressor) return;
+    this.compressor.threshold.value = this.compressorSettings.threshold;
+    this.compressor.knee.value = this.compressorSettings.knee;
+    this.compressor.ratio.value = this.compressorSettings.ratio;
+    this.compressor.attack.value = this.compressorSettings.attack;
+    this.compressor.release.value = this.compressorSettings.release;
+  }
+
+  private computeDryGain() {
+    const reverbImpact = clamp(1 - this.reverbSettings.mix * 0.65, 0.3, 1);
+    return reverbImpact;
+  }
+
+  private appendRecordingChunk(chunk: Float32Array[]) {
+    if (!chunk || chunk.length === 0) {
+      return;
+    }
+    const safeChunk = chunk.map((channel) => new Float32Array(channel));
+    if (this.recordingChannelCount === 0) {
+      this.recordingChannelCount = safeChunk.length;
+    }
+    this.recordingChunks.push(safeChunk);
+    if (safeChunk[0]) {
+      this.recordingLength += safeChunk[0].length;
+    }
+  }
+
+  private disposeRecorderNode() {
+    if (this.recorderNode) {
+      try {
+        this.vocalPostGain.disconnect(this.recorderNode as unknown as AudioNode);
+      } catch (error) {
+        // ignore disconnection errors
+      }
+      if (this.recorderNode instanceof AudioWorkletNode) {
+        this.recorderNode.port.onmessage = null;
+      } else {
+        (this.recorderNode as ScriptProcessorNode).onaudioprocess = null;
+      }
+      try {
+        (this.recorderNode as unknown as AudioNode).disconnect();
+      } catch (error) {
+        // ignore
+      }
+      this.recorderNode = null;
+    }
+    if (this.recorderMonitor) {
+      try {
+        this.recorderMonitor.disconnect();
+      } catch (error) {
+        // ignore
+      }
+      this.recorderMonitor = null;
+    }
+  }
+
+  private async prepareRecorderNode(context: AudioContext) {
+    this.disposeRecorderNode();
+    this.recordingChunks = [];
+    this.recordingLength = 0;
+    this.recordingChannelCount = 0;
+    this.recordingSampleRate = context.sampleRate;
+
+    if (typeof AudioWorkletNode !== 'undefined' && context.audioWorklet) {
+      try {
+        if (!this.audioWorkletModuleLoaded) {
+          await context.audioWorklet.addModule(new URL('./recorderWorklet.js', import.meta.url));
+          this.audioWorkletModuleLoaded = true;
+        }
+        const node = new AudioWorkletNode(context, 'vocal-recorder', {
+          numberOfInputs: 1,
+          numberOfOutputs: 0
+        });
+        node.port.onmessage = (event) => {
+          const data = event.data as Float32Array[];
+          if (Array.isArray(data)) {
+            this.appendRecordingChunk(data);
+          }
+        };
+        this.recorderNode = node;
+        this.vocalPostGain.connect(node);
+        return;
+      } catch (error) {
+        console.warn('Falling back to ScriptProcessor for recording', error);
+      }
+    }
+
+    const channelCount = Math.max(1, this.vocalPostGain.channelCount || this.vocalPostGain.numberOfOutputs || 1);
+    const processor = context.createScriptProcessor(4096, channelCount, 1);
+    processor.onaudioprocess = (event) => {
+      const chunk: Float32Array[] = [];
+      for (let channel = 0; channel < event.inputBuffer.numberOfChannels; channel += 1) {
+        const channelData = event.inputBuffer.getChannelData(channel);
+        chunk.push(new Float32Array(channelData));
+      }
+      this.appendRecordingChunk(chunk);
+    };
+    const monitor = context.createGain();
+    monitor.gain.value = 0;
+    processor.connect(monitor);
+    monitor.connect(context.destination);
+    this.vocalPostGain.connect(processor);
+    this.recorderMonitor = monitor;
+    this.recorderNode = processor;
+  }
+
+  private buildRecordedBuffer(context: AudioContext) {
+    if (!this.recordingChunks.length || this.recordingChannelCount === 0 || this.recordingLength === 0) {
+      return context.createBuffer(1, 1, context.sampleRate);
+    }
+    const buffer = context.createBuffer(this.recordingChannelCount, this.recordingLength, this.recordingSampleRate);
+    const channelData: Float32Array[] = [];
+    for (let channel = 0; channel < this.recordingChannelCount; channel += 1) {
+      channelData[channel] = buffer.getChannelData(channel);
+    }
+    let offset = 0;
+    this.recordingChunks.forEach((chunk) => {
+      const length = chunk[0]?.length ?? 0;
+      for (let channel = 0; channel < this.recordingChannelCount; channel += 1) {
+        const target = channelData[channel];
+        const source = chunk[channel] ?? chunk[0];
+        if (target && source) {
+          target.set(source, offset);
+        }
+      }
+      offset += length;
+    });
+    return buffer;
+  }
+
+  private createWaveform(buffer: AudioBuffer, resolution = 512) {
+    const data: number[] = [];
+    if (!buffer) {
+      return data;
+    }
+    const totalSamples = buffer.length;
+    const channels = buffer.numberOfChannels;
+    if (totalSamples === 0 || channels === 0) {
+      return data;
+    }
+    const samplesPerBucket = Math.max(1, Math.floor(totalSamples / resolution));
+    const bucketCount = Math.min(resolution, Math.ceil(totalSamples / samplesPerBucket));
+    for (let bucket = 0; bucket < bucketCount; bucket += 1) {
+      let peak = 0;
+      const start = bucket * samplesPerBucket;
+      const end = Math.min(totalSamples, start + samplesPerBucket);
+      for (let index = start; index < end; index += 1) {
+        let sum = 0;
+        for (let channel = 0; channel < channels; channel += 1) {
+          const channelData = buffer.getChannelData(channel);
+          sum += Math.abs(channelData[index]);
+        }
+        const value = sum / channels;
+        if (value > peak) {
+          peak = value;
+        }
+      }
+      data.push(peak);
+    }
+    const max = data.reduce((acc, value) => Math.max(acc, value), 0);
+    if (max > 0) {
+      for (let i = 0; i < data.length; i += 1) {
+        data[i] = Math.min(1, data[i] / max);
+      }
+    }
+    return data;
+  }
+
+  get isPlaying() {
+    return this._isPlaying;
+  }
+
+  get isRecording() {
+    return this._isRecording;
+  }
+
+  get beatDuration() {
+    return this.beatBuffer?.duration ?? null;
+  }
+
+  get vocalDuration() {
+    return this.vocalBuffer?.duration ?? null;
+  }
+
+  getBeatWaveform() {
+    return this.beatWaveform;
+  }
+
+  getVocalWaveform() {
+    return this.vocalWaveform;
+  }
+
+  async loadBeat(file: File): Promise<BeatAnalysis> {
+    const context = this.ensureContext();
+    await context.resume();
+    const arrayBuffer = await file.arrayBuffer();
+    const buffer = await context.decodeAudioData(arrayBuffer);
+    this.beatBuffer = buffer;
+    this.beatWaveform = this.createWaveform(buffer);
+    const { tempo, downbeatOffset } = this.analyseBeat(buffer);
+    this.beatTempo = tempo;
+    this.beatDownbeatOffset = downbeatOffset;
+    return {
+      duration: buffer.duration,
+      tempo,
+      downbeatOffset
+    };
+  }
+
+  async startPlayback(): Promise<PlaybackAlignment> {
+    const context = this.ensureContext();
+    await context.resume();
+    if (!this.beatBuffer && !this.vocalBuffer) {
+      throw new Error('Add a beat or record vocals before playback');
+    }
+    this.stopPlayback();
+
+    const activeSources: AudioBufferSourceNode[] = [];
+    const baseStartTime = context.currentTime + 0.1;
+    this.lastAlignment = {
+      alignmentShift: null,
+      quantizedTarget: null
+    };
+
+    if (this.beatBuffer) {
+      const source = context.createBufferSource();
+      source.buffer = this.beatBuffer;
+      source.playbackRate.value = 1;
+      source.connect(this.beatGain);
+      activeSources.push(source);
+      this.currentBeatSource = source;
+      source.start(baseStartTime);
+    }
+
+    if (this.vocalBuffer) {
+      const source = context.createBufferSource();
+      source.buffer = this.vocalBuffer;
+      source.connect(this.vocalGain);
+      let startTime = baseStartTime;
+      let offset = 0;
+      if (this.beatTempo && this.vocalOnset !== null) {
+        const beatLength = 60 / this.beatTempo;
+        const quantized = Math.round(this.vocalOnset / beatLength) * beatLength;
+        const clampedQuantized = Math.max(0, quantized);
+        if (clampedQuantized <= this.vocalOnset) {
+          offset = clamp(this.vocalOnset - clampedQuantized, 0, this.vocalBuffer.duration);
+        } else {
+          startTime += clampedQuantized - this.vocalOnset;
+        }
+        this.lastAlignment = {
+          alignmentShift: clampedQuantized - this.vocalOnset,
+          quantizedTarget: clampedQuantized
+        };
+      }
+      source.start(startTime, offset);
+      activeSources.push(source);
+      this.currentVocalSource = source;
+    }
+
+    activeSources.forEach((source) => {
+      source.onended = () => {
+        if (this.currentBeatSource === source) {
+          this.currentBeatSource = null;
+        }
+        if (this.currentVocalSource === source) {
+          this.currentVocalSource = null;
+        }
+        if (!this.currentBeatSource && !this.currentVocalSource) {
+          this._isPlaying = false;
+          this.onPlaybackStateChange?.(this._isPlaying);
+        }
+      };
+    });
+
+    if (activeSources.length > 0) {
+      this._isPlaying = true;
+      this.onPlaybackStateChange?.(this._isPlaying);
+    }
+    return this.lastAlignment;
+  }
+
+  stopPlayback() {
+    if (this.currentBeatSource) {
+      try {
+        this.currentBeatSource.onended = null;
+        this.currentBeatSource.stop();
+      } catch (error) {
+        // node may already be stopped
+      }
+      this.currentBeatSource = null;
+    }
+
+    if (this.currentVocalSource) {
+      try {
+        this.currentVocalSource.onended = null;
+        this.currentVocalSource.stop();
+      } catch (error) {
+        // ignore
+      }
+      this.currentVocalSource = null;
+    }
+
+    if (this._isPlaying) {
+      this._isPlaying = false;
+      this.onPlaybackStateChange?.(this._isPlaying);
+    }
+  }
+
+  async startRecording() {
+    const context = this.ensureContext();
+    await context.resume();
+    if (this._isRecording) {
+      return;
+    }
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: {
+        channelCount: 2,
+        echoCancellation: false,
+        noiseSuppression: false,
+        autoGainControl: false,
+        sampleRate: context.sampleRate
+      }
+    });
+    this.micStream = stream;
+    this.micSource = context.createMediaStreamSource(stream);
+    this.micSource.connect(this.vocalGain);
+
+    await this.prepareRecorderNode(context);
+    this._isRecording = true;
+    this.onRecordingStateChange?.(this._isRecording);
+  }
+
+  async stopRecording() {
+    if (!this._isRecording) {
+      return null;
+    }
+    const context = this.ensureContext();
+    const buffer = this.buildRecordedBuffer(context);
+    this.vocalBuffer = buffer;
+    this.vocalWaveform = this.createWaveform(buffer);
+    this.vocalOnset = this.measureOnset(buffer);
+    this._isRecording = false;
+    this.onRecordingStateChange?.(this._isRecording);
+    this.onVocalUpdated?.(buffer.duration);
+    this.cleanupMic();
+    return buffer;
+  }
+
+  private cleanupMic() {
+    if (this.micSource) {
+      try {
+        this.micSource.disconnect();
+      } catch (error) {
+        // ignore disconnection error
+      }
+      this.micSource = null;
+    }
+    if (this.micStream) {
+      this.micStream.getTracks().forEach((track) => track.stop());
+      this.micStream = null;
+    }
+    this.disposeRecorderNode();
+    this.recordingChunks = [];
+    this.recordingLength = 0;
+    this.recordingChannelCount = 0;
+  }
+
+  setVolumeSettings(settings: Partial<VolumeSettings>) {
+    this.volumeSettings = { ...this.volumeSettings, ...settings };
+    if (this.beatGain && settings.beat !== undefined) {
+      this.beatGain.gain.value = clamp(settings.beat, 0, 2);
+    }
+    if (this.vocalGain && settings.vocal !== undefined) {
+      this.vocalGain.gain.value = clamp(settings.vocal, 0, 2);
+    }
+    if (this.masterGain && settings.master !== undefined) {
+      this.masterGain.gain.value = clamp(settings.master, 0, 2);
+    }
+  }
+
+  setEQSettings(settings: Partial<EQSettings>) {
+    this.eqSettings = { ...this.eqSettings, ...settings };
+    if (this.eqLow) {
+      this.eqLow.gain.value = this.eqSettings.low;
+    }
+    if (this.eqMid) {
+      this.eqMid.gain.value = this.eqSettings.mid;
+    }
+    if (this.eqHigh) {
+      this.eqHigh.gain.value = this.eqSettings.high;
+    }
+  }
+
+  setCompressorSettings(settings: Partial<CompressorSettings>) {
+    this.compressorSettings = { ...this.compressorSettings, ...settings };
+    this.updateCompressorNode();
+  }
+
+  setDelaySettings(settings: Partial<DelaySettings>) {
+    this.delaySettings = { ...this.delaySettings, ...settings };
+    if (this.delayNode && settings.time !== undefined) {
+      this.delayNode.delayTime.value = clamp(settings.time, 0, 1.5);
+    }
+    if (this.delayFeedback && settings.feedback !== undefined) {
+      this.delayFeedback.gain.value = clamp(settings.feedback, 0, 0.95);
+    }
+    if (this.delayInput && settings.mix !== undefined) {
+      this.delayInput.gain.value = clamp(settings.mix, 0, 1);
+    }
+    if (this.delayWet && settings.mix !== undefined) {
+      this.delayWet.gain.value = clamp(settings.mix, 0, 1.2);
+    }
+  }
+
+  setReverbSettings(settings: Partial<ReverbSettings>) {
+    const updated: ReverbSettings = { ...this.reverbSettings, ...settings };
+    this.reverbSettings = updated;
+    if (this.reverbInput && settings.mix !== undefined) {
+      this.reverbInput.gain.value = clamp(settings.mix, 0, 1.2);
+    }
+    if (this.reverbWet && settings.mix !== undefined) {
+      this.reverbWet.gain.value = clamp(settings.mix, 0, 1.2);
+    }
+    if (this.masterDryGain) {
+      this.masterDryGain.gain.value = this.computeDryGain();
+    }
+    if (settings.duration !== undefined || settings.decay !== undefined) {
+      this.refreshReverbImpulse();
+    }
+  }
+
+  getPlaybackDuration() {
+    return Math.max(this.beatBuffer?.duration ?? 0, this.vocalBuffer?.duration ?? 0);
+  }
+
+  async exportMix() {
+    const context = this.ensureContext();
+    await context.resume();
+    const duration = this.getPlaybackDuration();
+    if (duration <= 0) {
+      throw new Error('Nothing to export. Load a beat or record vocals first.');
+    }
+    const recorder = new MediaRecorder(this.recordDestination.stream);
+    const chunks: Blob[] = [];
+    recorder.ondataavailable = (event) => {
+      if (event.data.size > 0) {
+        chunks.push(event.data);
+      }
+    };
+
+    const recordingPromise = new Promise<Blob>((resolve, reject) => {
+      recorder.onerror = (event) => {
+        reject((event as unknown as { error: Error }).error || new Error('Recording failed'));
+      };
+      recorder.onstop = () => {
+        resolve(new Blob(chunks, { type: 'audio/webm' }));
+      };
+    });
+
+    await this.startPlayback();
+    recorder.start();
+
+    window.setTimeout(() => {
+      if (recorder.state === 'recording') {
+        recorder.stop();
+      }
+    }, duration * 1000 + 600);
+
+    return recordingPromise;
+  }
+
+  clearVocalTake() {
+    this.vocalBuffer = null;
+    this.vocalOnset = null;
+    this.vocalWaveform = null;
+    this.lastAlignment = {
+      alignmentShift: null,
+      quantizedTarget: null
+    };
+    this.onVocalUpdated?.(null);
+  }
+
+  dispose() {
+    this.stopPlayback();
+    this.cleanupMic();
+    if (this.context) {
+      this.context.close();
+      this.context = null;
+    }
+  }
+
+  getBeatTempo() {
+    return this.beatTempo;
+  }
+
+  getBeatDownbeatOffset() {
+    return this.beatDownbeatOffset;
+  }
+
+  getLastAlignment() {
+    return this.lastAlignment;
+  }
+
+  private analyseBeat(buffer: AudioBuffer) {
+    try {
+      const sampleRate = buffer.sampleRate;
+      const step = Math.max(1, Math.floor(sampleRate / 500));
+      const downsampledRate = sampleRate / step;
+      const frames = Math.floor(buffer.length / step);
+      const envelope = new Float32Array(frames);
+      for (let i = 0; i < frames; i += 1) {
+        let sum = 0;
+        for (let channel = 0; channel < buffer.numberOfChannels; channel += 1) {
+          const channelData = buffer.getChannelData(channel);
+          sum += Math.abs(channelData[i * step] ?? 0);
+        }
+        envelope[i] = sum / buffer.numberOfChannels;
+      }
+
+      // Smooth the envelope for more stable autocorrelation.
+      const smoothed = new Float32Array(frames);
+      const smoothWindow = 4;
+      for (let i = 0; i < frames; i += 1) {
+        let acc = 0;
+        let count = 0;
+        for (let j = -smoothWindow; j <= smoothWindow; j += 1) {
+          const index = i + j;
+          if (index >= 0 && index < frames) {
+            acc += envelope[index];
+            count += 1;
+          }
+        }
+        smoothed[i] = count > 0 ? acc / count : 0;
+      }
+
+      const minBpm = 60;
+      const maxBpm = 180;
+      const minLag = Math.floor((60 / maxBpm) * downsampledRate);
+      const maxLag = Math.floor((60 / minBpm) * downsampledRate);
+      let bestLag = 0;
+      let bestScore = -Infinity;
+      for (let lag = minLag; lag <= maxLag; lag += 1) {
+        let score = 0;
+        for (let i = 0; i < frames - lag; i += 1) {
+          score += smoothed[i] * smoothed[i + lag];
+        }
+        if (score > bestScore) {
+          bestScore = score;
+          bestLag = lag;
+        }
+      }
+
+      const tempo = bestLag > 0 ? (60 * downsampledRate) / bestLag : null;
+
+      let downbeatOffset: number | null = null;
+      if (tempo) {
+        const searchWindow = Math.min(frames, Math.floor(downsampledRate * 8));
+        let peak = 0;
+        for (let i = 0; i < searchWindow; i += 1) {
+          if (smoothed[i] > peak) {
+            peak = smoothed[i];
+          }
+        }
+        const threshold = peak * 0.6;
+        for (let i = 0; i < searchWindow; i += 1) {
+          if (smoothed[i] >= threshold) {
+            downbeatOffset = i / downsampledRate;
+            break;
+          }
+        }
+      }
+
+      return {
+        tempo,
+        downbeatOffset
+      };
+    } catch (error) {
+      console.warn('Beat analysis failed', error);
+      return {
+        tempo: null,
+        downbeatOffset: null
+      };
+    }
+  }
+
+  private measureOnset(buffer: AudioBuffer) {
+    const sampleRate = buffer.sampleRate;
+    const step = Math.max(1, Math.floor(sampleRate / 1000));
+    const frames = Math.floor(buffer.length / step);
+    const envelope = new Float32Array(frames);
+    for (let i = 0; i < frames; i += 1) {
+      let sum = 0;
+      for (let channel = 0; channel < buffer.numberOfChannels; channel += 1) {
+        const channelData = buffer.getChannelData(channel);
+        sum += Math.abs(channelData[i * step] ?? 0);
+      }
+      envelope[i] = sum / buffer.numberOfChannels;
+    }
+
+    let peak = 0;
+    for (let i = 0; i < frames; i += 1) {
+      if (envelope[i] > peak) {
+        peak = envelope[i];
+      }
+    }
+    if (peak <= 0.00001) {
+      return 0;
+    }
+    const threshold = peak * 0.2;
+    for (let i = 0; i < frames; i += 1) {
+      if (envelope[i] >= threshold) {
+        return i / (sampleRate / step);
+      }
+    }
+    return 0;
+  }
+}
+
+export default AudioEngine;

--- a/src/audio/recorderWorklet.js
+++ b/src/audio/recorderWorklet.js
@@ -1,0 +1,17 @@
+class VocalRecorderProcessor extends AudioWorkletProcessor {
+  process(inputs) {
+    const input = inputs[0];
+    if (!input || input.length === 0) {
+      return true;
+    }
+    const payload = input.map((channel) => {
+      const clone = new Float32Array(channel.length);
+      clone.set(channel);
+      return clone;
+    });
+    this.port.postMessage(payload);
+    return true;
+  }
+}
+
+registerProcessor('vocal-recorder', VocalRecorderProcessor);

--- a/src/components/SliderControl.css
+++ b/src/components/SliderControl.css
@@ -1,0 +1,57 @@
+
+.slider-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.4rem;
+  background: rgba(12, 12, 14, 0.9);
+  border: 1px solid rgba(255, 255, 255, 0.05);
+  border-radius: 0.75rem;
+  padding: 0.75rem 1rem;
+  box-shadow: inset 0 0 0 1px rgba(255, 48, 64, 0.04);
+}
+
+.slider-header {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+
+.slider-control input[type='range'] {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  height: 0.35rem;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(255, 48, 64, 0.95), rgba(139, 0, 24, 0.9));
+  outline: none;
+}
+
+.slider-control input[type='range']::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 2px solid #ff1f4b;
+  box-shadow: 0 0 10px rgba(255, 48, 64, 0.4);
+}
+
+.slider-control input[type='range']::-moz-range-thumb {
+  width: 1rem;
+  height: 1rem;
+  border-radius: 50%;
+  background: #ffffff;
+  border: 2px solid #ff1f4b;
+  box-shadow: 0 0 10px rgba(255, 48, 64, 0.4);
+}
+
+
+.slider-value {
+  font-weight: 600;
+  color: #f5f5f5;
+}

--- a/src/components/SliderControl.tsx
+++ b/src/components/SliderControl.tsx
@@ -1,0 +1,47 @@
+import { ChangeEvent } from 'react';
+import './SliderControl.css';
+
+type SliderControlProps = {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step?: number;
+  unit?: string;
+  onChange: (value: number) => void;
+};
+
+const formatNumber = (value: number) => {
+  if (Math.abs(value) >= 1000 || Math.abs(value) < 0.01) {
+    return value.toExponential(2);
+  }
+  return value.toFixed(2);
+};
+
+export function SliderControl({
+  label,
+  value,
+  min,
+  max,
+  step = 0.01,
+  unit,
+  onChange
+}: SliderControlProps) {
+  const handleInput = (event: ChangeEvent<HTMLInputElement>) => {
+    onChange(Number(event.target.value));
+  };
+
+  return (
+    <label className="slider-control">
+      <div className="slider-header">
+        <span>{label}</span>
+        <span className="slider-value">
+          {formatNumber(value)} {unit}
+        </span>
+      </div>
+      <input type="range" min={min} max={max} step={step} value={value} onChange={handleInput} />
+    </label>
+  );
+}
+
+export default SliderControl;

--- a/src/index.css
+++ b/src/index.css
@@ -1,0 +1,22 @@
+:root {
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  color: #f5f5f5;
+  background-color: #050505;
+  color-scheme: dark;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: radial-gradient(circle at top left, #1a1a1d 0%, #050505 70%);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+a {
+  color: inherit;
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
+  <React.StrictMode>
+    <App />
+  </React.StrictMode>
+);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx"
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/tsconfig.node.json
+++ b/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    host: '0.0.0.0'
+  }
+});


### PR DESCRIPTION
## Summary
- add a track editor lane view with beat and vocal waveform visualisation tied to tempo metadata
- stabilise vocal recordings by capturing audio through an AudioWorklet-backed tap with ScriptProcessor fallback and waveform extraction
- expose beat/vocal waveform data and alignment overlays in the UI with refreshed styling for the editor panel

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d3d406bd74832ebfe1c7d9b57c7337